### PR TITLE
Added abstraction layer for boundary condition application and stepper initialization, and the capability to add profiles to boundary conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - XLB is now installable via pip
 - Complete rewrite of the codebase for better modularity and extensibility based on "Operators" design pattern
 - Added NVIDIA's Warp backend for state-of-the-art performance
+- Added abstraction layer for boundary condition efficient encoding/decoding of auxiliary data
+- Added the capability to add profiles to boundary conditions

--- a/examples/cfd/lid_driven_cavity_2d_distributed.py
+++ b/examples/cfd/lid_driven_cavity_2d_distributed.py
@@ -10,15 +10,21 @@ class LidDrivenCavity2D_distributed(LidDrivenCavity2D):
     def __init__(self, omega, prescribed_vel, grid_shape, velocity_set, backend, precision_policy):
         super().__init__(omega, prescribed_vel, grid_shape, velocity_set, backend, precision_policy)
 
-    def setup_stepper(self, omega):
-        stepper = IncompressibleNavierStokesStepper(omega, boundary_conditions=self.boundary_conditions)
-        distributed_stepper = distribute(
+    def setup_stepper(self):
+        # Create the base stepper
+        stepper = IncompressibleNavierStokesStepper(
+            omega=self.omega,
+            grid=self.grid,
+            boundary_conditions=self.boundary_conditions,
+            collision_type="BGK",
+        )
+
+        # Distribute the stepper
+        self.stepper = distribute(
             stepper,
             self.grid,
             self.velocity_set,
         )
-        self.stepper = distributed_stepper
-        return
 
 
 if __name__ == "__main__":

--- a/xlb/helper/nse_solver.py
+++ b/xlb/helper/nse_solver.py
@@ -3,12 +3,33 @@ from xlb.grid import grid_factory
 from xlb.precision_policy import Precision
 from typing import Tuple
 
+def create_nse_fields(
+    grid_shape: Tuple[int, int, int] = None,
+    grid=None,
+    velocity_set=None,
+    compute_backend=None,
+    precision_policy=None,
+):
+    """Create fields for Navier-Stokes equation solver.
 
-def create_nse_fields(grid_shape: Tuple[int, int, int], velocity_set=None, compute_backend=None, precision_policy=None):
+    Args:
+        grid_shape: Tuple of grid dimensions. Required if grid is not provided.
+        grid: Optional Grid object. If provided, will be used instead of creating new grid.
+        velocity_set: Optional velocity set. Defaults to DefaultConfig.velocity_set.
+        compute_backend: Optional compute backend. Defaults to DefaultConfig.default_backend.
+        precision_policy: Optional precision policy. Defaults to DefaultConfig.default_precision_policy.
+
+    Returns:
+        Tuple of (grid, f_0, f_1, missing_mask, bc_mask)
+    """
     velocity_set = velocity_set or DefaultConfig.velocity_set
     compute_backend = compute_backend or DefaultConfig.default_backend
     precision_policy = precision_policy or DefaultConfig.default_precision_policy
-    grid = grid_factory(grid_shape, compute_backend=compute_backend)
+
+    if grid is None:
+        if grid_shape is None:
+            raise ValueError("grid_shape must be provided when grid is None")
+        grid = grid_factory(grid_shape, compute_backend=compute_backend)
 
     # Create fields
     f_0 = grid.create_field(cardinality=velocity_set.q, dtype=precision_policy.store_precision)

--- a/xlb/operator/boundary_condition/bc_zouhe.py
+++ b/xlb/operator/boundary_condition/bc_zouhe.py
@@ -7,7 +7,8 @@ from jax import jit
 import jax.lax as lax
 from functools import partial
 import warp as wp
-from typing import Any
+from typing import Any, Union, Tuple
+import numpy as np
 
 from xlb.velocity_set.velocity_set import VelocitySet
 from xlb.precision_policy import PrecisionPolicy
@@ -21,6 +22,7 @@ from xlb.operator.boundary_condition.boundary_condition_registry import (
     boundary_condition_registry,
 )
 from xlb.operator.equilibrium import QuadraticEquilibrium
+import jax
 
 
 class ZouHeBC(BoundaryCondition):
@@ -38,7 +40,8 @@ class ZouHeBC(BoundaryCondition):
     def __init__(
         self,
         bc_type,
-        prescribed_value,
+        profile=None,
+        prescribed_value: Union[float, Tuple[float, ...], np.ndarray] = None,
         velocity_set: VelocitySet = None,
         precision_policy: PrecisionPolicy = None,
         compute_backend: ComputeBackend = None,
@@ -50,7 +53,7 @@ class ZouHeBC(BoundaryCondition):
         assert bc_type in ["velocity", "pressure"], f"type = {bc_type} not supported! Use 'pressure' or 'velocity'."
         self.bc_type = bc_type
         self.equilibrium_operator = QuadraticEquilibrium()
-        self.prescribed_value = prescribed_value
+        self.profile = profile
 
         # Call the parent constructor
         super().__init__(
@@ -62,14 +65,75 @@ class ZouHeBC(BoundaryCondition):
             mesh_vertices,
         )
 
-        # Set the prescribed value for pressure or velocity
-        dim = self.velocity_set.d
-        if self.compute_backend == ComputeBackend.JAX:
-            self.prescribed_value = jnp.atleast_1d(prescribed_value)[(slice(None),) + (None,) * dim]
-            # TODO: this won't work if the prescribed values are a profile with the length of bdry indices!
+        # Handle prescribed value if provided
+        if prescribed_value is not None:
+            if profile is not None:
+                raise ValueError("Cannot specify both profile and prescribed_value")
+
+            # Convert input to numpy array for validation
+            if isinstance(prescribed_value, (tuple, list)):
+                prescribed_value = np.array(prescribed_value, dtype=np.float64)
+            elif isinstance(prescribed_value, (int, float)):
+                if bc_type == "pressure":
+                    prescribed_value = float(prescribed_value)
+                else:
+                    raise ValueError("Velocity prescribed_value must be a tuple or array")
+            elif isinstance(prescribed_value, np.ndarray):
+                prescribed_value = prescribed_value.astype(np.float64)
+
+            # Validate prescribed value
+            if bc_type == "velocity":
+                if not isinstance(prescribed_value, np.ndarray):
+                    raise ValueError("Velocity prescribed_value must be an array-like")
+
+                # Check for non-zero elements - only one element should be non-zero
+                non_zero_count = np.count_nonzero(prescribed_value)
+                if non_zero_count > 1:
+                    raise ValueError("This BC only supports normal prescribed values (only one non-zero element allowed)")
+
+            self.prescribed_value = prescribed_value
+            self.profile = self._create_constant_prescribed_profile()
+
+        # This BC needs auxilary data initialization before streaming
+        self.needs_aux_init = True
+
+        # This BC needs auxilary data recovery after streaming
+        self.needs_aux_recovery = True
+
+        # This BC needs one auxilary data for the density or normal velocity
+        self.num_of_aux_data = 1
 
         # This BC needs padding for finding missing directions when imposed on a geometry that is in the domain interior
         self.needs_padding = True
+
+    def _create_constant_prescribed_profile(self):
+        if self.bc_type == "velocity":
+
+            @wp.func
+            def prescribed_profile_warp(index: wp.vec3i):
+                # Get the non-zero value from prescribed_value
+                value = wp.static(
+                    self.precision_policy.store_precision.wp_dtype(float(self.prescribed_value[np.nonzero(self.prescribed_value)[0][0]]))
+                )
+                return wp.vec(value, length=1)
+
+            def prescribed_profile_jax():
+                return jnp.array(self.prescribed_value, dtype=self.precision_policy.store_precision.jax_dtype).reshape(-1, 1)
+
+        else:  # pressure
+
+            @wp.func
+            def prescribed_profile_warp(index: wp.vec3i):
+                value = wp.static(self.precision_policy.store_precision.wp_dtype(self.prescribed_value))
+                return wp.vec(value, length=1)
+
+            def prescribed_profile_jax():
+                return jnp.array(self.prescribed_value)
+
+        if self.compute_backend == ComputeBackend.JAX:
+            return prescribed_profile_jax
+        elif self.compute_backend == ComputeBackend.WARP:
+            return prescribed_profile_warp
 
     @partial(jit, static_argnums=(0,), inline=True)
     def _get_known_middle_mask(self, missing_mask):
@@ -84,13 +148,53 @@ class ZouHeBC(BoundaryCondition):
         normals = -jnp.tensordot(main_c, m, axes=(-1, 0))
         return normals
 
+    @partial(jit, static_argnums=(0, 2, 3), inline=True)
+    def _broadcast_prescribed_values(self, prescribed_values, prescribed_values_shape, target_shape):
+        """
+        Broadcasts `prescribed_values` to `target_shape` following specific rules:
+
+        - If `prescribed_values_shape` is (2, 1) or (3, 1) (for constant profiles),
+          broadcast along the last 2 or 3 dimensions of `target_shape` respectively.
+        - For other shapes, identify mismatched dimensions and broadcast only in that direction.
+        """
+        # Determine the number of dimensions to match
+        num_dims_prescribed = len(prescribed_values_shape)
+        num_dims_target = len(target_shape)
+
+        if num_dims_prescribed > num_dims_target:
+            raise ValueError("prescribed_values has more dimensions than target_shape")
+
+        # Insert singleton dimensions after the first dimension to match target_shape
+        if num_dims_prescribed < num_dims_target:
+            # Number of singleton dimensions to add
+            num_singleton = num_dims_target - num_dims_prescribed
+
+            if num_dims_prescribed == 0:
+                # If prescribed_values is scalar, reshape to all singleton dimensions
+                prescribed_values_shape = (1,) * num_dims_target
+            else:
+                # Insert singleton dimensions after the first dimension
+                prescribed_values_shape = (prescribed_values_shape[0], *(1,) * num_singleton, *prescribed_values_shape[1:])
+                prescribed_values = prescribed_values.reshape(prescribed_values_shape)
+
+        # Create broadcast shape based on the rules
+        broadcast_shape = []
+        for pv_dim, tgt_dim in zip(prescribed_values_shape, target_shape):
+            if pv_dim == 1 or pv_dim == tgt_dim:
+                broadcast_shape.append(tgt_dim)
+            else:
+                raise ValueError(f"Cannot broadcast dimension {pv_dim} to {tgt_dim}")
+
+        return jnp.broadcast_to(prescribed_values, target_shape)
+
     @partial(jit, static_argnums=(0,), inline=True)
     def get_rho(self, fpop, missing_mask):
         if self.bc_type == "velocity":
-            vel = self.prescribed_value
+            target_shape = (self.velocity_set.d,) + fpop.shape[1:]
+            vel = self._broadcast_prescribed_values(self.prescribed_values, self.prescribed_values.shape, target_shape)
             rho = self.calculate_rho(fpop, vel, missing_mask)
         elif self.bc_type == "pressure":
-            rho = self.prescribed_value
+            rho = self.prescribed_values
         else:
             raise ValueError(f"type = {self.bc_type} not supported! Use 'pressure' or 'velocity'.")
         return rho
@@ -98,9 +202,10 @@ class ZouHeBC(BoundaryCondition):
     @partial(jit, static_argnums=(0,), inline=True)
     def get_vel(self, fpop, missing_mask):
         if self.bc_type == "velocity":
-            vel = self.prescribed_value
+            target_shape = (self.velocity_set.d,) + fpop.shape[1:]
+            vel = self._broadcast_prescribed_values(self.prescribed_values, self.prescribed_values.shape, target_shape)
         elif self.bc_type == "pressure":
-            rho = self.prescribed_value
+            rho = self.prescribed_values
             vel = self.calculate_vel(fpop, rho, missing_mask)
         else:
             raise ValueError(f"type = {self.bc_type} not supported! Use 'pressure' or 'velocity'.")
@@ -134,14 +239,13 @@ class ZouHeBC(BoundaryCondition):
         return rho
 
     @partial(jit, static_argnums=(0,), inline=True)
-    def calculate_equilibrium(self, fpop, missing_mask):
+    def calculate_equilibrium(self, f_post, missing_mask):
         """
         This is the ZouHe method of calculating the missing macroscopic variables at the boundary.
         """
-        rho = self.get_rho(fpop, missing_mask)
-        vel = self.get_vel(fpop, missing_mask)
+        rho = self.get_rho(f_post, missing_mask)
+        vel = self.get_vel(f_post, missing_mask)
 
-        # compute feq at the boundary
         feq = self.equilibrium_operator(rho, vel)
         return feq
 
@@ -176,14 +280,10 @@ class ZouHeBC(BoundaryCondition):
         # assign placeholders for both u and rho based on prescribed_value
         _d = self.velocity_set.d
         _q = self.velocity_set.q
-        u = self.prescribed_value if self.bc_type == "velocity" else (0,) * _d
-        rho = self.prescribed_value if self.bc_type == "pressure" else 0.0
 
         # Set local constants TODO: This is a hack and should be fixed with warp update
         # _u_vec = wp.vec(_d, dtype=self.compute_dtype)
         _u_vec = wp.vec(self.velocity_set.d, dtype=self.compute_dtype)
-        _rho = self.compute_dtype(rho)
-        _u = _u_vec(u[0], u[1], u[2]) if _d == 3 else _u_vec(u[0], u[1])
         _opp_indices = self.velocity_set.opp_indices
         _c = self.velocity_set.c
         _c_float = self.velocity_set.c_float
@@ -231,61 +331,78 @@ class ZouHeBC(BoundaryCondition):
         def functional_velocity(
             index: Any,
             timestep: Any,
-            missing_mask: Any,
-            f_0: Any,
-            f_1: Any,
+            _missing_mask: Any,
             f_pre: Any,
             f_post: Any,
+            _f_pre: Any,
+            _f_post: Any,
         ):
             # Post-streaming values are only modified at missing direction
-            _f = f_post
+            _f = _f_post
 
             # Find normal vector
-            normals = get_normal_vectors(missing_mask)
+            normals = get_normal_vectors(_missing_mask)
 
             # calculate rho
-            fsum = _get_fsum(_f, missing_mask)
+            fsum = _get_fsum(_f, _missing_mask)
             unormal = self.compute_dtype(0.0)
+
+            # Find the value of u from the missing directions
+            for l in range(_q):
+                # Since we are only considering normal velocity, we only need to find one value (all values are the same in the missing directions)
+                if _missing_mask[l] == wp.uint8(1):
+                    # Create velocity vector by multiplying the prescribed value with the normal vector
+                    # TODO: This can be optimized by saving _missing_mask[l] in the bc class later since it is the same for all boundary cells
+                    prescribed_value = f_post[_opp_indices[l], index[0], index[1], index[2]]
+                    _u = -prescribed_value * normals
+                    break
+
             for d in range(_d):
                 unormal += _u[d] * normals[d]
+
             _rho = fsum / (self.compute_dtype(1.0) + unormal)
 
             # impose non-equilibrium bounceback
-            feq = self.equilibrium_operator.warp_functional(_rho, _u)
-            _f = bounceback_nonequilibrium(_f, feq, missing_mask)
+            _feq = self.equilibrium_operator.warp_functional(_rho, _u)
+            _f = bounceback_nonequilibrium(_f, _feq, _missing_mask)
             return _f
 
         @wp.func
         def functional_pressure(
             index: Any,
             timestep: Any,
-            missing_mask: Any,
-            f_0: Any,
-            f_1: Any,
+            _missing_mask: Any,
             f_pre: Any,
             f_post: Any,
+            _f_pre: Any,
+            _f_post: Any,
         ):
             # Post-streaming values are only modified at missing direction
-            _f = f_post
+            _f = _f_post
 
             # Find normal vector
-            normals = get_normal_vectors(missing_mask)
+            normals = get_normal_vectors(_missing_mask)
+
+            # Find the value of rho from the missing directions
+            for q in range(_q):
+                # Since we need only one scalar value, we only need to find one value (all values are the same in the missing directions)
+                if _missing_mask[q] == wp.uint8(1):
+                    _rho = f_post[_opp_indices[q], index[0], index[1], index[2]]
+                    break
 
             # calculate velocity
-            fsum = _get_fsum(_f, missing_mask)
+            fsum = _get_fsum(_f, _missing_mask)
             unormal = -self.compute_dtype(1.0) + fsum / _rho
             _u = unormal * normals
 
             # impose non-equilibrium bounceback
             feq = self.equilibrium_operator.warp_functional(_rho, _u)
-            _f = bounceback_nonequilibrium(_f, feq, missing_mask)
+            _f = bounceback_nonequilibrium(_f, feq, _missing_mask)
             return _f
 
         if self.bc_type == "velocity":
             functional = functional_velocity
         elif self.bc_type == "pressure":
-            functional = functional_pressure
-        elif self.bc_type == "velocity":
             functional = functional_pressure
 
         kernel = self._construct_kernel(functional)

--- a/xlb/operator/stepper/nse_stepper.py
+++ b/xlb/operator/stepper/nse_stepper.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from xlb import DefaultConfig
 from xlb.compute_backend import ComputeBackend
+from xlb.precision_policy import Precision
 from xlb.operator import Operator
 from xlb.operator.stream import Stream
 from xlb.operator.collision import BGK, KBC
@@ -16,31 +17,114 @@ from xlb.operator.stepper import Stepper
 from xlb.operator.boundary_condition.boundary_condition import ImplementationStep
 from xlb.operator.boundary_condition.boundary_condition_registry import boundary_condition_registry
 from xlb.operator.collision import ForcedCollision
+from xlb.operator.boundary_masker import IndicesBoundaryMasker, MeshBoundaryMasker
+from xlb.helper import check_bc_overlaps
+from xlb.helper.nse_solver import create_nse_fields
 
 
 class IncompressibleNavierStokesStepper(Stepper):
-    def __init__(self, omega, boundary_conditions=[], collision_type="BGK", forcing_scheme="exact_difference", force_vector=None):
-        velocity_set = DefaultConfig.velocity_set
-        precision_policy = DefaultConfig.default_precision_policy
-        compute_backend = DefaultConfig.default_backend
+    def __init__(
+        self,
+        omega,
+        grid,
+        boundary_conditions=[],
+        collision_type="BGK",
+        forcing_scheme="exact_difference",
+        force_vector=None,
+    ):
+        super().__init__(grid, boundary_conditions)
 
         # Construct the collision operator
         if collision_type == "BGK":
-            self.collision = BGK(omega, velocity_set, precision_policy, compute_backend)
+            self.collision = BGK(omega, self.velocity_set, self.precision_policy, self.compute_backend)
         elif collision_type == "KBC":
-            self.collision = KBC(omega, velocity_set, precision_policy, compute_backend)
+            self.collision = KBC(omega, self.velocity_set, self.precision_policy, self.compute_backend)
 
         if force_vector is not None:
             self.collision = ForcedCollision(collision_operator=self.collision, forcing_scheme=forcing_scheme, force_vector=force_vector)
 
         # Construct the operators
-        self.stream = Stream(velocity_set, precision_policy, compute_backend)
-        self.equilibrium = QuadraticEquilibrium(velocity_set, precision_policy, compute_backend)
-        self.macroscopic = Macroscopic(velocity_set, precision_policy, compute_backend)
+        self.stream = Stream(self.velocity_set, self.precision_policy, self.compute_backend)
+        self.equilibrium = QuadraticEquilibrium(self.velocity_set, self.precision_policy, self.compute_backend)
+        self.macroscopic = Macroscopic(self.velocity_set, self.precision_policy, self.compute_backend)
 
-        operators = [self.macroscopic, self.equilibrium, self.collision, self.stream]
+    def prepare_fields(self, initializer=None):
+        """Prepare the fields required for the stepper.
 
-        super().__init__(operators, boundary_conditions)
+        Args:
+            initializer: Optional operator to initialize the distribution functions.
+                        If provided, it should be a callable that takes (grid, velocity_set,
+                        precision_policy, compute_backend) as arguments and returns initialized f_0.
+                        If None, default equilibrium initialization is used with rho=1 and u=0.
+
+        Returns:
+            Tuple of (f_0, f_1, bc_mask, missing_mask):
+                - f_0: Initial distribution functions
+                - f_1: Copy of f_0 for double-buffering
+                - bc_mask: Boundary condition mask indicating which BC applies to each node
+                - missing_mask: Mask indicating which populations are missing at boundary nodes
+        """
+        # Create fields using the helper function
+        _, f_0, f_1, missing_mask, bc_mask = create_nse_fields(
+            grid=self.grid, velocity_set=self.velocity_set, compute_backend=self.compute_backend, precision_policy=self.precision_policy
+        )
+
+        # Initialize distribution functions if initializer is provided
+        if initializer is not None:
+            f_0 = initializer(self.grid, self.velocity_set, self.precision_policy, self.compute_backend)
+        else:
+            from xlb.helper.initializers import initialize_eq
+            f_0 = initialize_eq(f_0, self.grid, self.velocity_set, self.precision_policy, self.compute_backend)
+
+        # Copy f_0 using backend-specific copy to f_1
+        if self.compute_backend == ComputeBackend.JAX:
+            f_1 = f_0.copy()
+        else:
+            wp.copy(f_1, f_0)
+
+        # Process boundary conditions and update masks
+        bc_mask, missing_mask = self._process_boundary_conditions(self.boundary_conditions, bc_mask, missing_mask)
+        # Initialize auxiliary data if needed
+        f_0, f_1 = self._initialize_auxiliary_data(self.boundary_conditions, f_0, f_1, bc_mask, missing_mask)
+
+        return f_0, f_1, bc_mask, missing_mask
+
+    @classmethod
+    def _process_boundary_conditions(cls, boundary_conditions, bc_mask, missing_mask):
+        """Process boundary conditions and update boundary masks."""
+        # Check for boundary condition overlaps
+        check_bc_overlaps(boundary_conditions, DefaultConfig.velocity_set.d, DefaultConfig.default_backend)
+        # Create boundary maskers
+        indices_masker = IndicesBoundaryMasker(
+            velocity_set=DefaultConfig.velocity_set,
+            precision_policy=DefaultConfig.default_precision_policy,
+            compute_backend=DefaultConfig.default_backend,
+        )
+        # Split boundary conditions by type
+        bc_with_vertices = [bc for bc in boundary_conditions if bc.mesh_vertices is not None]
+        bc_with_indices = [bc for bc in boundary_conditions if bc.indices is not None]
+        # Process indices-based boundary conditions
+        if bc_with_indices:
+            bc_mask, missing_mask = indices_masker(bc_with_indices, bc_mask, missing_mask)
+        # Process mesh-based boundary conditions for 3D
+        if DefaultConfig.velocity_set.d == 3 and bc_with_vertices:
+            mesh_masker = MeshBoundaryMasker(
+                velocity_set=DefaultConfig.velocity_set,
+                precision_policy=DefaultConfig.default_precision_policy,
+                compute_backend=DefaultConfig.default_backend,
+            )
+            for bc in bc_with_vertices:
+                bc_mask, missing_mask = mesh_masker(bc, bc_mask, missing_mask)
+
+        return bc_mask, missing_mask
+
+    @staticmethod
+    def _initialize_auxiliary_data(boundary_conditions, f_0, f_1, bc_mask, missing_mask):
+        """Initialize auxiliary data for boundary conditions that require it."""
+        for bc in boundary_conditions:
+            if bc.needs_aux_init and not bc.is_initialized_with_aux_data:
+                f_0, f_1 = bc.aux_data_init(f_0, f_1, bc_mask, missing_mask)
+        return f_0, f_1
 
     @Operator.register_backend(ComputeBackend.JAX)
     @partial(jit, static_argnums=(0))
@@ -76,7 +160,7 @@ class IncompressibleNavierStokesStepper(Stepper):
 
         # Apply collision type boundary conditions
         for bc in self.boundary_conditions:
-            f_post_collision = bc.prepare_bc_auxilary_data(f_post_stream, f_post_collision, bc_mask, missing_mask)
+            f_post_collision = bc.update_bc_auxilary_data(f_post_stream, f_post_collision, bc_mask, missing_mask)
             if bc.implementation_step == ImplementationStep.COLLISION:
                 f_post_collision = bc(
                     f_post_stream,
@@ -108,6 +192,8 @@ class IncompressibleNavierStokesStepper(Stepper):
         # Group active boundary conditions
         active_bcs = set(boundary_condition_registry.id_to_bc[bc.id] for bc in self.boundary_conditions)
 
+        _opp_indices = self.velocity_set.opp_indices
+
         @wp.func
         def apply_bc(
             index: Any,
@@ -134,7 +220,7 @@ class IncompressibleNavierStokesStepper(Stepper):
                             f_result = wp.static(self.boundary_conditions[i].warp_functional)(index, timestep, missing_mask, f_0, f_1, f_pre, f_post)
                     if wp.static(self.boundary_conditions[i].id in extrapolation_outflow_bc_ids):
                         if _boundary_id == wp.static(self.boundary_conditions[i].id):
-                            f_result = wp.static(self.boundary_conditions[i].prepare_bc_auxilary_data)(
+                            f_result = wp.static(self.boundary_conditions[i].update_bc_auxilary_data)(
                                 index, timestep, missing_mask, f_0, f_1, f_pre, f_post
                             )
             return f_result
@@ -160,6 +246,23 @@ class IncompressibleNavierStokesStepper(Stepper):
                     _missing_mask[l] = wp.uint8(0)
 
             return _f0_thread, _f1_thread, _missing_mask
+
+        @wp.func
+        def apply_aux_recovery_bc(
+            index: Any,
+            _boundary_id: Any,
+            _missing_mask: Any,
+            f_0: Any,
+            _f1_thread: Any,
+        ):
+            # Unroll the loop over boundary conditions
+            for i in range(wp.static(len(self.boundary_conditions))):
+                if wp.static(self.boundary_conditions[i].needs_aux_recovery):
+                    if _boundary_id == wp.static(self.boundary_conditions[i].id):
+                        # Perform the swapping of data
+                        for l in range(self.velocity_set.q):
+                            if _missing_mask[l] == wp.uint8(1):
+                                f_0[_opp_indices[l], index[0], index[1], index[2]] = self.store_dtype(_f1_thread[_opp_indices[l]])
 
         @wp.kernel
         def kernel(
@@ -192,13 +295,11 @@ class IncompressibleNavierStokesStepper(Stepper):
             # Apply post-collision boundary conditions
             _f_post_collision = apply_bc(index, timestep, _boundary_id, _missing_mask, f_0, f_1, _f_post_stream, _f_post_collision, False)
 
+            # Apply auxiliary recovery for boundary conditions (swapping)
+            apply_aux_recovery_bc(index, _boundary_id, _missing_mask, f_0, _f1_thread)
+
             # Store the result in f_1
             for l in range(self.velocity_set.q):
-                # TODO: Improve this later
-                if wp.static("GradsApproximationBC" in active_bcs):
-                    if _boundary_id == wp.static(boundary_condition_registry.bc_to_id["GradsApproximationBC"]):
-                        if _missing_mask[l] == wp.uint8(1):
-                            f_0[_opp_indices[l], index[0], index[1], index[2]] = self.store_dtype(_f1_thread[_opp_indices[l]])
                 f_1[l, index[0], index[1], index[2]] = self.store_dtype(_f_post_collision[l])
 
         return None, kernel

--- a/xlb/operator/stepper/stepper.py
+++ b/xlb/operator/stepper/stepper.py
@@ -8,25 +8,27 @@ class Stepper(Operator):
     Class that handles the construction of lattice boltzmann stepping operator
     """
 
-    def __init__(self, operators, boundary_conditions):
-        # Get the boundary condition ids
-        from xlb.operator.boundary_condition.boundary_condition_registry import boundary_condition_registry
-
-        self.operators = operators
+    def __init__(self, grid, boundary_conditions):
+        self.grid = grid
         self.boundary_conditions = boundary_conditions
-
         # Get velocity set, precision policy, and compute backend
-        velocity_sets = set([op.velocity_set for op in self.operators if op is not None])
-        assert len(velocity_sets) < 2, "All velocity sets must be the same. Got {}".format(velocity_sets)
-        velocity_set = DefaultConfig.velocity_set if not velocity_sets else velocity_sets.pop()
-
-        precision_policies = set([op.precision_policy for op in self.operators if op is not None])
-        assert len(precision_policies) < 2, "All precision policies must be the same. Got {}".format(precision_policies)
-        precision_policy = DefaultConfig.default_precision_policy if not precision_policies else precision_policies.pop()
-
-        compute_backends = set([op.compute_backend for op in self.operators if op is not None])
-        assert len(compute_backends) < 2, "All compute backends must be the same. Got {}".format(compute_backends)
-        compute_backend = DefaultConfig.default_backend if not compute_backends else compute_backends.pop()
+        velocity_set = DefaultConfig.velocity_set
+        precision_policy = DefaultConfig.default_precision_policy
+        compute_backend = DefaultConfig.default_backend
 
         # Initialize operator
         super().__init__(velocity_set, precision_policy, compute_backend)
+
+    def prepare_fields(self, initializer=None):
+        """Initialize the fields required for the stepper.
+
+        Args:
+            initializer: Optional operator to initialize the distribution functions.
+                        If provided, it should be a callable that takes (grid, velocity_set,
+                        precision_policy, compute_backend) as arguments and returns initialized f_0.
+                        If None, default equilibrium initialization is used with rho=1 and u=0.
+
+        Returns:
+            Tuple of (f_0, f_1, bc_mask, missing_mask)
+        """
+        raise NotImplementedError("Subclasses must implement prepare_fields()")


### PR DESCRIPTION
## Contributing Guidelines

<!-- Please make sure you have read and understood our contributing guidelines before submitting this PR -->
- [x] I have read and understood the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines

## Description

<!-- 
Thank you for your contribution! Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

- Added abstraction layer for boundary condition efficient encoding/decoding of auxiliary data
- Added the capability to add profiles to boundary conditions
- Allows mesh boundary masker to be called in JAX as well.
- Added abstraction layer to initialize fields and BCs inside stepper (Optionally called)
- Fixes  https://github.com/Autodesk/XLB/issues/74

## Type of change

<!-- Please select the options that are relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce. Include details of your test environment, and the test cases you ran.

- [ ] Test A
- [ ] Test B
-->
- [x] All pytest tests pass

<!-- To run the tests, execute the following command from the root of the repository:

```bash
pytest
```
 -->


## Linting and Code Formatting

Make sure the code follows the project's linting and formatting standards. This project uses **Ruff** for linting.

To run Ruff, execute the following command from the root of the repository:

```bash
ruff check .
```

<!-- You can also fix some linting errors automatically using Ruff:

```bash
ruff check . --fix
```
-->

- [x] Ruff passes
