### PR TITLE
Used center of f_1 as an additional storage and also fixed some bugs

### DIFF
--- a/examples/cfd/flow_past_sphere_3d.py
+++ b/examples/cfd/flow_past_sphere_3d.py
@@ -91,8 +91,8 @@ class FlowOverSphere:
         @wp.func
         def bc_profile_warp(index: wp.vec3i):
             # Poiseuille flow profile: parabolic velocity distribution
-            y = self.precision_policy.store_precision.wp_dtype(index[1])
-            z = self.precision_policy.store_precision.wp_dtype(index[2])
+            y = wp.float32(index[1])
+            z = wp.float32(index[2])
 
             # Calculate normalized distance from center
             y_center = y - (H_y / 2.0)

--- a/xlb/operator/boundary_condition/bc_regularized.py
+++ b/xlb/operator/boundary_condition/bc_regularized.py
@@ -222,13 +222,10 @@ class RegularizedBC(ZouHeBC):
             normals = get_normal_vectors(missing_mask)
 
             # Find the value of u from the missing directions
-            for l in range(_q):
-                # Since we are only considering normal velocity, we only need to find one value
-                if missing_mask[l] == wp.uint8(1):
-                    # Create velocity vector by multiplying the prescribed value with the normal vector
-                    prescribed_value = f_1[_opp_indices[l], index[0], index[1], index[2]]
-                    _u = -prescribed_value * normals
-                    break
+            # Since we are only considering normal velocity, we only need to find one value (stored at the center of f_1)
+            # Create velocity vector by multiplying the prescribed value with the normal vector
+            prescribed_value = f_1[0, index[0], index[1], index[2]]
+            _u = -prescribed_value * normals
 
             # calculate rho
             fsum = _get_fsum(_f, missing_mask)
@@ -262,11 +259,8 @@ class RegularizedBC(ZouHeBC):
             normals = get_normal_vectors(missing_mask)
 
             # Find the value of rho from the missing directions
-            for q in range(_q):
-                # Since we need only one scalar value, we only need to find one value
-                if missing_mask[q] == wp.uint8(1):
-                    _rho = f_1[_opp_indices[q], index[0], index[1], index[2]]
-                    break
+            # Since we need only one scalar value, we only need to find one value (stored at the center of f_1)
+            _rho = f_1[0, index[0], index[1], index[2]]
 
             # calculate velocity
             fsum = _get_fsum(_f, missing_mask)

--- a/xlb/operator/boundary_condition/boundary_condition.py
+++ b/xlb/operator/boundary_condition/boundary_condition.py
@@ -190,8 +190,13 @@ class BoundaryCondition(Operator):
                 prescribed_values = functional(index)
                 # Write the result for all q directions, but only store up to num_of_aux_data
                 # TODO: Somehow raise an error if the number of prescribed values does not match the number of missing directions
-                counter = wp.int32(0)
-                for l in range(self.velocity_set.q):
+
+                # The first BC auxiliary data is stored in the zero'th index of f_1 associated with its center.
+                f_1[0, index[0], index[1], index[2]] = self.store_dtype(prescribed_values[0])
+                counter = wp.int32(1)
+
+                # The other remaining BC auxiliary data are stored in missing directions of f_1.
+                for l in range(1, self.velocity_set.q):
                     if _missing_mask[l] == wp.uint8(1) and counter < _num_of_aux_data:
                         f_1[_opp_indices[l], index[0], index[1], index[2]] = self.store_dtype(prescribed_values[counter])
                         counter += 1

--- a/xlb/operator/equilibrium/quadratic_equilibrium.py
+++ b/xlb/operator/equilibrium/quadratic_equilibrium.py
@@ -20,7 +20,7 @@ class QuadraticEquilibrium(Equilibrium):
     def jax_implementation(self, rho, u):
         cu = 3.0 * jnp.tensordot(self.velocity_set.c, u, axes=(0, 0))
         usqr = 1.5 * jnp.sum(jnp.square(u), axis=0, keepdims=True)
-        w = self.velocity_set.w.reshape((-1,) + (1,) * (len(rho.shape) - 1))
+        w = self.velocity_set.w.reshape((-1,) + (1,) * self.velocity_set.d)
         feq = rho * w * (1.0 + cu * (1.0 + 0.5 * cu) - usqr)
         return feq
 


### PR DESCRIPTION
## Contributing Guidelines

<!-- Please make sure you have read and understood our contributing guidelines before submitting this PR -->
- [x] I have read and understood the [CONTRIBUTING.md](https://github.com/Autodesk/XLB/blob/main/CONTRIBUTING.md) guidelines


## Description

Added feature:

1. Added central location of output population (f_1) as another storage space for storing BC auxilary data since that's also available. 
2. Used this newly added space for allocating single auxilary data of ZouHe/Regularized which simplified the code and removed for-loops over lattice direction for reading the prescribed values. 

Fixed the following bugs:

1. Flow over sphere was not working with prescribed pressure in JAX
3. Flow over sphere was not working with FP64FP64 in WARP
4. Regularized or ZouHe were not working with prescribed velocity of ZERO vector associated with no-slip BC (straight wall).


<!-- 
Thank you for your contribution! Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->


## Type of change

<!-- Please select the options that are relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce. Include details of your test environment, and the test cases you ran.

- [ ] Test A
- [ ] Test B
-->
- [x] All pytest tests pass

<!-- To run the tests, execute the following command from the root of the repository:

```bash
pytest
```
 -->


## Linting and Code Formatting

Make sure the code follows the project's linting and formatting standards. This project uses **Ruff** for linting.

To run Ruff, execute the following command from the root of the repository:

```bash
ruff check .
```

<!-- You can also fix some linting errors automatically using Ruff:

```bash
ruff check . --fix
```
-->

- [x] Ruff passes
