### PR TITLE
Fixed the momentum exchange method in the JAX backend.

### DIFF
--- a/xlb/velocity_set/d3q19.py
+++ b/xlb/velocity_set/d3q19.py
@@ -16,7 +16,7 @@ class D3Q19(VelocitySet):
 
     def __init__(self, precision_policy, backend):
         # Construct the velocity vectors and weights
-        c = np.array([ci for ci in itertools.product([-1, 0, 1], repeat=3) if np.sum(np.abs(ci)) <= 2]).T
+        c = np.array([ci for ci in itertools.product([0, -1, 1], repeat=3) if np.sum(np.abs(ci)) <= 2]).T
         w = np.zeros(19)
         for i in range(19):
             if np.sum(np.abs(c[:, i])) == 0:


### PR DESCRIPTION
## Contributing Guidelines

<!-- Please make sure you have read and understood our contributing guidelines before submitting this PR -->
- [x] I have read and understood the [CONTRIBUTING.md](https://github.com/Autodesk/XLB/blob/main/CONTRIBUTING.md) guidelines


## Description

1. Fixed the momentum exchange method in the JAX backend (see https://github.com/Autodesk/XLB/issues/94)
2. Fixed the ordering of D3Q19 velocity set to ensure (0,0,0) is the first index like other velocity sets
3. Removed an unnecessary operation of aux recovery for ExtrapolationOutflow BC

I noticed that mlups_3d which relies on D3Q19 now gives tiny bit faster results (~ 0.1%) which could be due to item 2 above.

<!-- 
Thank you for your contribution! Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->


## Type of change

<!-- Please select the options that are relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce. Include details of your test environment, and the test cases you ran.

- [ ] Test A
- [ ] Test B
-->
- [x] All pytest tests pass

<!-- To run the tests, execute the following command from the root of the repository:

```bash
pytest
```
 -->


## Linting and Code Formatting

Make sure the code follows the project's linting and formatting standards. This project uses **Ruff** for linting.

To run Ruff, execute the following command from the root of the repository:

```bash
ruff check .
```

<!-- You can also fix some linting errors automatically using Ruff:

```bash
ruff check . --fix
```
-->

- [x] Ruff passes
