### PR TITLE
Improved KBC performance

### DIFF
--- a/xlb/operator/collision/kbc.py
+++ b/xlb/operator/collision/kbc.py
@@ -77,25 +77,27 @@ class KBC(Collision):
 
         # Perform collision
         delta_h = fneq - delta_s
-        gamma = inv_beta - (2.0 - inv_beta) * self.entropic_scalar_product(delta_s, delta_h, feq) / (
-            self.epsilon + self.entropic_scalar_product(delta_h, delta_h, feq)
-        )
+        sp1, sp2 = self.compute_entropic_scalar_products(delta_s, delta_h, feq)
+        gamma = inv_beta - (2.0 - inv_beta) * sp1 / (self.epsilon + sp2)
 
         fout = f - beta * (2.0 * delta_s + gamma[None, ...] * delta_h)
 
         return fout
 
     @partial(jit, static_argnums=(0,), inline=True)
-    def entropic_scalar_product(self, x: jnp.ndarray, y: jnp.ndarray, feq: jnp.ndarray):
+    def compute_entropic_scalar_products(self, delta_s: jnp.ndarray, delta_h: jnp.ndarray, feq: jnp.ndarray):
         """
-        Compute the entropic scalar product of x and y to approximate gamma in KBC.
+        Compute the entropic scalar products to approximate gamma in KBC.
 
         Returns
         -------
         jax.numpy.array
-            Entropic scalar product of x, y, and feq.
+            sp1 and sp2: Entropic scalar products of delta_s, delta_h, and feq.
         """
-        return jnp.sum(x * y / feq, axis=0)
+        temp = delta_h / feq
+        sp1 = jnp.sum(temp * delta_s, axis=0)
+        sp2 = jnp.sum(temp * delta_h, axis=0)
+        return sp1, sp2
 
     @partial(jit, static_argnums=(0,), inline=True)
     def decompose_shear_d3q27_jax(self, fneq):
@@ -247,18 +249,20 @@ class KBC(Collision):
 
             return s
 
-        # Construct functional for computing entropic scalar product
+        # Construct functional for computing entropic scalar products
         @wp.func
-        def entropic_scalar_product(
-            x: Any,
-            y: Any,
+        def compute_entropic_scalar_products(
+            delta_s: Any,
+            delta_h: Any,
             feq: Any,
         ):
-            e = wp.cw_div(wp.cw_mul(x, y), feq)
-            e_sum = self.compute_dtype(0.0)
+            temp = wp.cw_div(delta_h, feq)
+            sp1 = self.compute_dtype(0.0)
+            sp2 = self.compute_dtype(0.0)
             for i in range(self.velocity_set.q):
-                e_sum += e[i]
-            return e_sum
+                sp1 += temp[i] * delta_s[i]
+                sp2 += temp[i] * delta_h[i]
+            return sp1, sp2
 
         # Construct the functional
         @wp.func
@@ -285,9 +289,8 @@ class KBC(Collision):
             # Perform collision
             delta_h = fneq - delta_s
             two = self.compute_dtype(2.0)
-            gamma = _inv_beta - (two - _inv_beta) * entropic_scalar_product(delta_s, delta_h, feq) / (
-                _epsilon + entropic_scalar_product(delta_h, delta_h, feq)
-            )
+            sp1, sp2 = compute_entropic_scalar_products(delta_s, delta_h, feq)
+            gamma = _inv_beta - (two - _inv_beta) * sp1 / (_epsilon + sp2)
             fout = f - _beta * (two * delta_s + gamma * delta_h)
 
             return fout


### PR DESCRIPTION
## Contributing Guidelines

<!-- Please make sure you have read and understood our contributing guidelines before submitting this PR -->
- [x] I have read and understood the [CONTRIBUTING.md](https://github.com/Autodesk/XLB/blob/main/CONTRIBUTING.md) guidelines


## Description
The MLUPs performance of KBC has been improved by this simple combination of calls to the same function. `mlups_3d.py` with KBC + D3Q27 on A6000 gives:

- Before this contribution, MLUPs: 2281.69
- After this contribution: MLUPs: 3138.76

<!-- 
Thank you for your contribution! Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->


## Type of change

<!-- Please select the options that are relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce. Include details of your test environment, and the test cases you ran.

- [ ] Test A
- [ ] Test B
-->
- [x] All pytest tests pass

<!-- To run the tests, execute the following command from the root of the repository:

```bash
pytest
```
 -->


## Linting and Code Formatting

Make sure the code follows the project's linting and formatting standards. This project uses **Ruff** for linting.

To run Ruff, execute the following command from the root of the repository:

```bash
ruff check .
```

<!-- You can also fix some linting errors automatically using Ruff:

```bash
ruff check . --fix
```
-->

- [x] Ruff passes
