### PR TITLE
Added handling profile for BC and reduced register pressure

### DIFF
--- a/xlb/operator/boundary_condition/bc_zouhe.py
+++ b/xlb/operator/boundary_condition/bc_zouhe.py
@@ -116,7 +116,7 @@ class ZouHeBC(BoundaryCondition):
         _prescribed_value = self.prescribed_value
 
         @wp.func
-        def prescribed_profile_warp(index: Any):
+        def prescribed_profile_warp(index: wp.vec3i):
             return wp.vec(_prescribed_value, length=1)
 
         def prescribed_profile_jax():

--- a/xlb/operator/boundary_condition/boundary_condition.py
+++ b/xlb/operator/boundary_condition/boundary_condition.py
@@ -102,7 +102,7 @@ class BoundaryCondition(Operator):
             index = wp.vec3i(i, j, k)
 
             # read tid data
-            _f_pre, _f_post, _boundary_id, _missing_mask = bc_helper.get_thread_data(f_pre, f_post, bc_mask, missing_mask, index)
+            _f_pre, _f_post, _boundary_id, _missing_mask = bc_helper.get_bc_thread_data(f_pre, f_post, bc_mask, missing_mask, index)
 
             # Apply the boundary condition
             if _boundary_id == _id:
@@ -140,7 +140,7 @@ class BoundaryCondition(Operator):
             index = wp.vec3i(i, j, k)
 
             # read tid data
-            _f_0, _f_1, _boundary_id, _missing_mask = bc_helper.get_thread_data(f_0, f_1, bc_mask, missing_mask, index)
+            _, _, _boundary_id, _missing_mask = bc_helper.get_bc_thread_data(f_0, f_1, bc_mask, missing_mask, index)
 
             # Apply the functional
             if _boundary_id == _id:
@@ -194,7 +194,7 @@ class BoundaryCondition(Operator):
                 @wp.func
                 def aux_data_init_cl(index: Any):
                     # read tid data
-                    _, _, _boundary_id, _missing_mask = bc_helper.neon_get_thread_data(f_0_pn, f_1_pn, bc_mask_pn, missing_mask_pn, index)
+                    _, _, _boundary_id, _missing_mask = bc_helper.neon_get_bc_thread_data(f_0_pn, f_1_pn, bc_mask_pn, missing_mask_pn, index)
 
                     # Apply the functional
                     if _boundary_id == _id:
@@ -280,7 +280,7 @@ class BoundaryCondition(Operator):
                 @wp.func
                 def aux_data_init_cl(index: Any):
                     # read tid data
-                    _, _, _boundary_id, _missing_mask = bc_helper.neon_get_thread_data(f_0_pn, f_1_pn, bc_mask_pn, missing_mask_pn, index)
+                    _, _, _boundary_id, _missing_mask = bc_helper.neon_get_bc_thread_data(f_0_pn, f_1_pn, bc_mask_pn, missing_mask_pn, index)
 
                     # Apply the functional
                     if _boundary_id == _id:

--- a/xlb/operator/boundary_condition/helper_functions_bc.py
+++ b/xlb/operator/boundary_condition/helper_functions_bc.py
@@ -34,7 +34,7 @@ class HelperFunctionsBC(object):
         momentum_flux = MomentumFlux(velocity_set, precision_policy, compute_backend)
 
         @wp.func
-        def get_thread_data(
+        def get_bc_thread_data(
             f_pre: wp.array4d(dtype=Any),
             f_post: wp.array4d(dtype=Any),
             bc_mask: wp.array4d(dtype=wp.uint8),
@@ -59,7 +59,7 @@ class HelperFunctionsBC(object):
             return _f_pre, _f_post, _boundary_id, _missing_mask
 
         @wp.func
-        def neon_get_thread_data(
+        def neon_get_bc_thread_data(
             f_pre_pn: Any,
             f_post_pn: Any,
             bc_mask_pn: Any,
@@ -142,9 +142,9 @@ class HelperFunctionsBC(object):
                 fpop[l] = feq[l] + fpop1
             return fpop
 
-        self.get_thread_data = get_thread_data
+        self.get_bc_thread_data = get_bc_thread_data
         self.get_bc_fsum = get_bc_fsum
         self.get_normal_vectors = get_normal_vectors
         self.bounceback_nonequilibrium = bounceback_nonequilibrium
         self.regularize_fpop = regularize_fpop
-        self.neon_get_thread_data = neon_get_thread_data
+        self.neon_get_bc_thread_data = neon_get_bc_thread_data

--- a/xlb/operator/boundary_masker/multires_boundary_masker.py
+++ b/xlb/operator/boundary_masker/multires_boundary_masker.py
@@ -42,7 +42,6 @@ class MultiresBoundaryMasker(Operator):
         assert bc_mask.get_grid().get_name() == "mGrid", f"Operation {self.__class__.__name} is only applicable to multi-resolution cases"
 
         # number of levels
-        # indices_per_level = []
         num_levels = bc_mask.get_grid().get_num_levels()
         for level in range(num_levels):
             # Use the warp backend to create dense fields to be written in multi-res NEON fields


### PR DESCRIPTION
## Contributing Guidelines

<!-- Please make sure you have read and understood our contributing guidelines before submitting this PR -->
- [x] I have read and understood the [CONTRIBUTING.md](https://github.com/Autodesk/XLB/blob/main/CONTRIBUTING.md) guidelines


## Description

<!-- 
Thank you for your contribution! Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

- Reduced register pressure by avoiding reading f1_thread for all cells
- Added capability to handle BC profiles in MRES

## Type of change

<!-- Please select the options that are relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce. Include details of your test environment, and the test cases you ran.

- [ ] Test A
- [ ] Test B
-->
- [x] All pytest tests pass

<!-- To run the tests, execute the following command from the root of the repository:

```bash
pytest
```
 -->


## Linting and Code Formatting

Make sure the code follows the project's linting and formatting standards. This project uses **Ruff** for linting.

To run Ruff, execute the following command from the root of the repository:

```bash
ruff check .
```

<!-- You can also fix some linting errors automatically using Ruff:

```bash
ruff check . --fix
```
-->

- [x] Ruff passes
