### PR TITLE
Fix Warp 1.14 compatibility

### DIFF
--- a/examples/cfd/flow_past_sphere_3d.py
+++ b/examples/cfd/flow_past_sphere_3d.py
@@ -98,7 +98,7 @@ def bc_profile():
             r_squared = (two * y_center / H_y) ** two + (two * z_center / H_z) ** two
 
             # Parabolic profile: u = u_max * (1 - r²)
-            return wp.vec(wp_dtype(u_max) * wp.max(wp_dtype(0.0), wp_dtype(1.0) - r_squared), length=1)
+            return wp.vector(wp_dtype(u_max) * wp.max(wp_dtype(0.0), wp_dtype(1.0) - r_squared), length=1)
 
         return bc_profile_warp
 

--- a/examples/cfd/multires_flow_past_sphere_3d.py
+++ b/examples/cfd/multires_flow_past_sphere_3d.py
@@ -171,7 +171,7 @@ def bc_profile():
     one = dtype(1.0)
     zero = dtype(0.0)
     u_max_wp = dtype(u_max)
-    _u_vec = wp.vec(velocity_set.d, dtype=dtype)
+    _u_vec = wp.types.vector(length=velocity_set.d, dtype=dtype)
 
     @wp.func
     def bc_profile_warp(index: wp.vec3i):
@@ -191,7 +191,7 @@ def bc_profile():
         # return _u_vec(u_max_wp * wp.max(zero, one - r_squared), zero, zero)
 
         # For Regularized and ZouHe
-        return wp.vec(u_max_wp * wp.max(zero, one - r_squared), length=1)
+        return wp.vector(u_max_wp * wp.max(zero, one - r_squared), length=1)
 
     return bc_profile_warp
 

--- a/examples/cfd/rotating_sphere_3d.py
+++ b/examples/cfd/rotating_sphere_3d.py
@@ -115,7 +115,7 @@ sphere_cross_section = np.pi * diam**2 / 4.0
 def bc_profile():
     """Build a Warp function returning the rotational wall velocity at a voxel."""
     dtype = precision_policy.compute_precision.wp_dtype
-    _u_vec = wp.vec(velocity_set.d, dtype=dtype)
+    _u_vec = wp.types.vector(length=velocity_set.d, dtype=dtype)
     angular_velocity = _u_vec(0.0, rot_rate, 0.0)
     origin_np = shift + diam / 2
     origin_wp = _u_vec(origin_np[0], origin_np[1], origin_np[2])

--- a/examples/ibm/airfoil_ibm.py
+++ b/examples/ibm/airfoil_ibm.py
@@ -70,7 +70,7 @@ def bc_profile(precision_policy, grid_shape, u_max):
 
     @wp.func
     def bc_profile_warp(index: wp.vec3i):
-        return wp.vec(dtype(u_max_d), length=1)
+        return wp.vector(dtype(u_max_d), length=1)
 
     return bc_profile_warp
 

--- a/examples/ibm/sphere_ibm.py
+++ b/examples/ibm/sphere_ibm.py
@@ -57,7 +57,7 @@ def bc_profile(precision_policy, grid_shape, u_max):
 
     @wp.func
     def bc_profile_warp(index: wp.vec3i):
-        return wp.vec(_dtype(u_max_d), length=1)
+        return wp.vector(_dtype(u_max_d), length=1)
 
     return bc_profile_warp
 

--- a/examples/ibm/wind_turbine_ibm.py
+++ b/examples/ibm/wind_turbine_ibm.py
@@ -43,7 +43,7 @@ def bc_profile(precision_policy, grid_shape, u_max):
 
     @wp.func
     def bc_profile_warp(index: wp.vec3i):
-        return wp.vec(u_max_d, length=1)
+        return wp.vector(u_max_d, length=1)
 
     return bc_profile_warp
 

--- a/examples/ibm/windtunnel_ibm.py
+++ b/examples/ibm/windtunnel_ibm.py
@@ -239,7 +239,7 @@ def bc_profile(precision_policy, grid_shape, u_max):
         z_center = z - (L_z / _dtype(2.0))
         r_sq = ((_dtype(2.0) * y_center) / L_y) ** _dtype(2.0) + ((_dtype(2.0) * z_center) / L_z) ** _dtype(2.0)
         velocity_x = u_max_d * wp.max(_dtype(0.0), _dtype(1.0) - r_sq)
-        return wp.vec(velocity_x, length=1)
+        return wp.vector(velocity_x, length=1)
 
     return bc_profile_warp
 
@@ -559,11 +559,11 @@ cx_list = [c[0] for c in wheel_centers]
 cy_list = [c[1] for c in wheel_centers]
 cz_list = [c[2] for c in wheel_centers]
 
-_wheel_starts = wp.constant(wp.vec(len(starts_list), dtype=int)(starts_list))
-_wheel_ends = wp.constant(wp.vec(len(ends_list), dtype=int)(ends_list))
-_wheel_centers_x = wp.constant(wp.vec(len(cx_list), dtype=float)(cx_list))
-_wheel_centers_y = wp.constant(wp.vec(len(cy_list), dtype=float)(cy_list))
-_wheel_centers_z = wp.constant(wp.vec(len(cz_list), dtype=float)(cz_list))
+_wheel_starts = wp.constant(wp.types.vector(length=len(starts_list), dtype=int)(starts_list))
+_wheel_ends = wp.constant(wp.types.vector(length=len(ends_list), dtype=int)(ends_list))
+_wheel_centers_x = wp.constant(wp.types.vector(length=len(cx_list), dtype=float)(cx_list))
+_wheel_centers_y = wp.constant(wp.types.vector(length=len(cy_list), dtype=float)(cy_list))
+_wheel_centers_z = wp.constant(wp.types.vector(length=len(cz_list), dtype=float)(cz_list))
 
 bc_list = setup_boundary_conditions(grid, velocity_set, precision_policy, grid_shape, u_max)
 stepper = setup_stepper(grid, bc_list, omega)

--- a/tests/install/flow_past_sphere_3d_test.py
+++ b/tests/install/flow_past_sphere_3d_test.py
@@ -105,7 +105,7 @@ def _run_flow_past_sphere_for_backend(compute_backend: ComputeBackend) -> None:
             y_center = y - (H_y_w / two)
             z_center = z - (H_z_w / two)
             r_squared = (two * y_center / H_y_w) ** two + (two * z_center / H_z_w) ** two
-            return wp.vec(wp_dtype(u_max) * wp.max(wp_dtype(0.0), wp_dtype(1.0) - r_squared), length=1)
+            return wp.vector(wp_dtype(u_max) * wp.max(wp_dtype(0.0), wp_dtype(1.0) - r_squared), length=1)
 
         return bc_profile_warp
 

--- a/xlb/helper/initializers.py
+++ b/xlb/helper/initializers.py
@@ -13,6 +13,7 @@ are supported:
 """
 
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 from xlb import DefaultConfig
 from xlb.operator import Operator
@@ -166,7 +167,7 @@ class CustomInitializer(Operator):
 
     def _construct_warp(self):
         _q = self.velocity_set.q
-        _u_vec = wp.vec(self.velocity_set.d, dtype=self.compute_dtype)
+        _u_vec = wp.types.vector(length=self.velocity_set.d, dtype=self.compute_dtype)
         _u = _u_vec(self.constant_velocity_vector[0], self.constant_velocity_vector[1], self.constant_velocity_vector[2])
         _rho = self.compute_dtype(self.constant_density)
         _w = self.velocity_set.w

--- a/xlb/operator/boundary_condition/bc_equilibrium.py
+++ b/xlb/operator/boundary_condition/bc_equilibrium.py
@@ -7,6 +7,7 @@ from jax import jit
 import jax.lax as lax
 from functools import partial
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Tuple, Any
 
 from xlb.velocity_set.velocity_set import VelocitySet
@@ -81,7 +82,7 @@ class EquilibriumBC(BoundaryCondition):
 
     def _construct_warp(self):
         # Set local constants TODO: This is a hack and should be fixed with warp update
-        _u_vec = wp.vec(self.velocity_set.d, dtype=self.compute_dtype)
+        _u_vec = wp.types.vector(length=self.velocity_set.d, dtype=self.compute_dtype)
         _rho = self.compute_dtype(self.rho)
         _u = _u_vec(self.u[0], self.u[1], self.u[2]) if self.velocity_set.d == 3 else _u_vec(self.u[0], self.u[1])
 

--- a/xlb/operator/boundary_condition/bc_fullway_bounce_back.py
+++ b/xlb/operator/boundary_condition/bc_fullway_bounce_back.py
@@ -10,6 +10,7 @@ from jax import jit
 import jax.lax as lax
 from functools import partial
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 
 from xlb.velocity_set.velocity_set import VelocitySet
@@ -59,7 +60,7 @@ class FullwayBounceBackBC(BoundaryCondition):
         # Set local constants TODO: This is a hack and should be fixed with warp update
         _opp_indices = self.velocity_set.opp_indices
         _q = wp.constant(self.velocity_set.q)
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
 
         # Construct the functional for this BC
         @wp.func

--- a/xlb/operator/boundary_condition/bc_halfway_bounce_back.py
+++ b/xlb/operator/boundary_condition/bc_halfway_bounce_back.py
@@ -12,6 +12,7 @@ from jax import jit
 import jax.lax as lax
 from functools import partial
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any, Union, Tuple, Callable
 import numpy as np
 
@@ -89,7 +90,7 @@ class HalfwayBounceBackBC(BoundaryCondition):
             if self.compute_backend in [ComputeBackend.WARP, ComputeBackend.NEON]:
                 if self.velocity_set.d == 2:
                     prescribed_value = np.array([prescribed_value[0], prescribed_value[1], 0.0], dtype=np.float64)
-                prescribed_value = wp.vec(3, dtype=self.compute_dtype)(prescribed_value)
+                prescribed_value = wp.types.vector(length=3, dtype=self.compute_dtype)(prescribed_value)
             self.profile = self._create_constant_prescribed_profile(prescribed_value)
 
     def _create_constant_prescribed_profile(self, prescribed_value):
@@ -101,7 +102,7 @@ class HalfwayBounceBackBC(BoundaryCondition):
 
             return prescribed_profile_jax
 
-        _u_vec = wp.vec(3, dtype=self.compute_dtype)
+        _u_vec = wp.types.vector(length=3, dtype=self.compute_dtype)
 
         @wp.func
         def prescribed_profile_warp(index: Any, time: Any):

--- a/xlb/operator/boundary_condition/bc_hybrid.py
+++ b/xlb/operator/boundary_condition/bc_hybrid.py
@@ -19,6 +19,7 @@ import inspect
 from jax import jit
 from functools import partial
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any, Union, Tuple, Callable
 import numpy as np
 
@@ -149,7 +150,7 @@ class HybridBC(BoundaryCondition):
                 prescribed_value = np.array([prescribed_value[0], prescribed_value[1], 0.0], dtype=np.float64)
 
             # create a constant prescribed profile
-            _u_vec = wp.vec(3, dtype=self.compute_dtype)
+            _u_vec = wp.types.vector(length=3, dtype=self.compute_dtype)
             prescribed_value = _u_vec(prescribed_value)
 
             @wp.func

--- a/xlb/operator/boundary_condition/bc_zouhe.py
+++ b/xlb/operator/boundary_condition/bc_zouhe.py
@@ -16,6 +16,7 @@ from jax import jit
 import jax.lax as lax
 from functools import partial
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any, Union, Tuple, Callable
 import numpy as np
 
@@ -150,7 +151,7 @@ class ZouHeBC(BoundaryCondition):
 
         @wp.func
         def prescribed_profile_warp(index: wp.vec3i):
-            return wp.vec(_prescribed_value, length=1)
+            return wp.vector(_prescribed_value, length=1)
 
         def prescribed_profile_jax():
             return jnp.array(_prescribed_value, dtype=self.precision_policy.store_precision.jax_dtype).reshape(-1, 1)

--- a/xlb/operator/boundary_condition/helper_functions_bc.py
+++ b/xlb/operator/boundary_condition/helper_functions_bc.py
@@ -15,6 +15,7 @@ import inspect
 from typing import Any, Callable
 
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 
 from xlb.velocity_set.velocity_set import VelocitySet
 from xlb.precision_policy import PrecisionPolicy
@@ -60,9 +61,9 @@ class HelperFunctionsBC(object):
         _c = self.velocity_set.c
         _c_float = self.velocity_set.c_float
         _qi = self.velocity_set.qi
-        _u_vec = wp.vec(_d, dtype=compute_dtype)
-        _f_vec = wp.vec(_q, dtype=compute_dtype)
-        _missing_mask_vec = wp.vec(_q, dtype=wp.uint8)  # TODO fix vec bool
+        _u_vec = wp.types.vector(length=_d, dtype=compute_dtype)
+        _f_vec = wp.types.vector(length=_q, dtype=compute_dtype)
+        _missing_mask_vec = wp.types.vector(length=_q, dtype=wp.uint8)  # TODO fix vec bool
 
         # Define the operator needed for computing equilibrium
         equilibrium = QuadraticEquilibrium(velocity_set, precision_policy, compute_backend)
@@ -412,7 +413,7 @@ class EncodeAuxiliaryData(Operator):
         _opp_indices = self.velocity_set.opp_indices
         _id = self.boundary_id
         _num_of_aux_data = self.num_of_aux_data
-        _aux_vec = wp.vec(_num_of_aux_data, dtype=self.compute_dtype)
+        _aux_vec = wp.types.vector(length=_num_of_aux_data, dtype=self.compute_dtype)
 
         @wp.func
         def encoder_functional(

--- a/xlb/operator/collision/bgk.py
+++ b/xlb/operator/collision/bgk.py
@@ -5,6 +5,7 @@ Bhatnagar-Gross-Krook (BGK) single-relaxation-time collision operator.
 import jax.numpy as jnp
 from jax import jit
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 
 from xlb.compute_backend import ComputeBackend
@@ -34,7 +35,7 @@ class BGK(Collision):
     def _construct_warp(self):
         # Set local constants TODO: This is a hack and should be fixed with warp update
         _w = self.velocity_set.w
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
 
         # Construct the functional
         @wp.func

--- a/xlb/operator/collision/forced_collision.py
+++ b/xlb/operator/collision/forced_collision.py
@@ -5,6 +5,7 @@ Collision operator with external body-force correction.
 import jax.numpy as jnp
 from jax import jit
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 
 from xlb.compute_backend import ComputeBackend
@@ -58,8 +59,8 @@ class ForcedCollision(Collision):
 
     def _construct_warp(self):
         # Set local constants TODO: This is a hack and should be fixed with warp update
-        _u_vec = wp.vec(self.velocity_set.d, dtype=self.compute_dtype)
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
+        _u_vec = wp.types.vector(length=self.velocity_set.d, dtype=self.compute_dtype)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
 
         # Construct the functional
         @wp.func

--- a/xlb/operator/collision/kbc.py
+++ b/xlb/operator/collision/kbc.py
@@ -5,6 +5,7 @@ KBC collision operator for LBM.
 import jax.numpy as jnp
 from jax import jit
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 from functools import partial
 
@@ -179,8 +180,8 @@ class KBC(Collision):
             raise NotImplementedError("Velocity set not supported for warp backend: {}".format(type(self.velocity_set)))
 
         # Set local constants TODO: This is a hack and should be fixed with warp update
-        _u_vec = wp.vec(self.velocity_set.d, dtype=self.compute_dtype)
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
+        _u_vec = wp.types.vector(length=self.velocity_set.d, dtype=self.compute_dtype)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
         _epsilon = wp.constant(self.compute_dtype(self.epsilon))
 
         @wp.func

--- a/xlb/operator/collision/smagorinsky_les_bgk.py
+++ b/xlb/operator/collision/smagorinsky_les_bgk.py
@@ -5,6 +5,7 @@ BGK collision operator with Smagorinsky large-eddy-simulation sub-grid model.
 import jax.numpy as jnp
 from jax import jit
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 import numpy as np
 
@@ -70,10 +71,10 @@ class SmagorinskyLESBGK(Collision):
         _d = self.velocity_set.d
         _cc = self.velocity_set.cc
         _smagorinsky_coef = wp.constant(self.compute_dtype(self.smagorinsky_coef))
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
         _pi_dim = self.velocity_set.d * (self.velocity_set.d + 1) // 2
-        _pi_vec = wp.vec(_pi_dim, dtype=self.compute_dtype)
-        _u_vec = wp.vec(self.velocity_set.d, dtype=self.compute_dtype)
+        _pi_vec = wp.types.vector(length=_pi_dim, dtype=self.compute_dtype)
+        _u_vec = wp.types.vector(length=self.velocity_set.d, dtype=self.compute_dtype)
 
         # Construct the functional
         @wp.func

--- a/xlb/operator/equilibrium/multires_quadratic_equilibrium.py
+++ b/xlb/operator/equilibrium/multires_quadratic_equilibrium.py
@@ -3,6 +3,7 @@ Multi-resolution quadratic equilibrium operator for the Neon backend.
 """
 
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 from xlb.compute_backend import ComputeBackend
 from xlb.operator.equilibrium import QuadraticEquilibrium
@@ -29,7 +30,7 @@ class MultiresQuadraticEquilibrium(QuadraticEquilibrium):
         functional, _ = self._construct_warp()
 
         # Set local constants TODO: This is a hack and should be fixed with warp update
-        _u_vec = wp.vec(self.velocity_set.d, dtype=self.compute_dtype)
+        _u_vec = wp.types.vector(length=self.velocity_set.d, dtype=self.compute_dtype)
 
         @neon.Container.factory(name="QuadraticEquilibrium")
         def container(

--- a/xlb/operator/equilibrium/quadratic_equilibrium.py
+++ b/xlb/operator/equilibrium/quadratic_equilibrium.py
@@ -2,6 +2,7 @@ from functools import partial
 import jax.numpy as jnp
 from jax import jit
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 import os
 
 from typing import Any
@@ -33,8 +34,8 @@ class QuadraticEquilibrium(Equilibrium):
         # Set local constants TODO: This is a hack and should be fixed with warp update
         _c = self.velocity_set.c
         _w = self.velocity_set.w
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
-        _u_vec = wp.vec(self.velocity_set.d, dtype=self.compute_dtype)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
+        _u_vec = wp.types.vector(length=self.velocity_set.d, dtype=self.compute_dtype)
 
         # Construct the equilibrium functional
         @wp.func
@@ -109,7 +110,7 @@ class QuadraticEquilibrium(Equilibrium):
         functional, _ = self._construct_warp()
 
         # Set local constants TODO: This is a hack and should be fixed with warp update
-        _u_vec = wp.vec(self.velocity_set.d, dtype=self.compute_dtype)
+        _u_vec = wp.types.vector(length=self.velocity_set.d, dtype=self.compute_dtype)
 
         @neon.Container.factory(name="QuadraticEquilibrium")
         def container(

--- a/xlb/operator/force/exact_difference_force.py
+++ b/xlb/operator/force/exact_difference_force.py
@@ -1,6 +1,7 @@
 from functools import partial
 from jax import jit, lax
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 
 from xlb import DefaultConfig
@@ -77,7 +78,7 @@ class ExactDifference(Operator):
 
     def _construct_warp(self):
         _d = self.velocity_set.d
-        _u_vec = wp.vec(_d, dtype=self.compute_dtype)
+        _u_vec = wp.types.vector(length=_d, dtype=self.compute_dtype)
         if _d == 2:
             _force = _u_vec(self.force_vector[0], self.force_vector[1])
         else:

--- a/xlb/operator/force/momentum_transfer.py
+++ b/xlb/operator/force/momentum_transfer.py
@@ -2,6 +2,7 @@ from functools import partial
 import jax.numpy as jnp
 from jax import jit, lax
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 from enum import Enum, auto
 
@@ -70,7 +71,7 @@ class FetchPopulations(Operator):
         return f_post_collision, f_post_stream
 
     def _construct_warp(self):
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
 
         @wp.func
         def functional_stream_then_collide(
@@ -168,7 +169,7 @@ class MomentumTransfer(Operator):
 
         if self.compute_backend != ComputeBackend.JAX:
             # Allocate the force vector (the total integral value will be computed)
-            _u_vec = wp.vec(self.velocity_set.d, dtype=self.compute_dtype)
+            _u_vec = wp.types.vector(length=self.velocity_set.d, dtype=self.compute_dtype)
             self.force = wp.zeros((1), dtype=_u_vec)
 
     @Operator.register_backend(ComputeBackend.JAX)
@@ -214,8 +215,8 @@ class MomentumTransfer(Operator):
         # Set local constants
         _c = self.velocity_set.c
         _opp_indices = self.velocity_set.opp_indices
-        _u_vec = wp.vec(self.velocity_set.d, dtype=self.compute_dtype)
-        _missing_mask_vec = wp.vec(self.velocity_set.q, dtype=wp.uint8)
+        _u_vec = wp.types.vector(length=self.velocity_set.d, dtype=self.compute_dtype)
+        _missing_mask_vec = wp.types.vector(length=self.velocity_set.q, dtype=wp.uint8)
         _no_slip_id = self.no_slip_bc_instance.id
 
         # Find velocity index for (0, 0, 0)

--- a/xlb/operator/macroscopic/first_moment.py
+++ b/xlb/operator/macroscopic/first_moment.py
@@ -2,6 +2,7 @@ from functools import partial
 import jax.numpy as jnp
 from jax import jit
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 
 from xlb.compute_backend import ComputeBackend
@@ -19,8 +20,8 @@ class FirstMoment(Operator):
 
     def _construct_warp(self):
         _c = self.velocity_set.c
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
-        _u_vec = wp.vec(self.velocity_set.d, dtype=self.compute_dtype)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
+        _u_vec = wp.types.vector(length=self.velocity_set.d, dtype=self.compute_dtype)
 
         @wp.func
         def neumaier_sum_component(d: int, f: _f_vec):

--- a/xlb/operator/macroscopic/macroscopic.py
+++ b/xlb/operator/macroscopic/macroscopic.py
@@ -2,6 +2,7 @@ from functools import partial
 import jax.numpy as jnp
 from jax import jit
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 
 from xlb.compute_backend import ComputeBackend
@@ -26,7 +27,7 @@ class Macroscopic(Operator):
         return rho, u
 
     def _construct_warp(self):
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
 
         @wp.func
         def functional(f: _f_vec):
@@ -73,7 +74,7 @@ class Macroscopic(Operator):
         functional, _ = self._construct_warp()
 
         # Set local vectors
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
 
         @neon.Container.factory("macroscopic")
         def container(

--- a/xlb/operator/macroscopic/multires_macroscopic.py
+++ b/xlb/operator/macroscopic/multires_macroscopic.py
@@ -6,6 +6,7 @@ from functools import partial
 import jax.numpy as jnp
 from jax import jit
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 
 from xlb.compute_backend import ComputeBackend
@@ -34,7 +35,7 @@ class MultiresMacroscopic(Macroscopic):
         # This is because the neon backend relies on the warp functionals for its operations.
         self.zero_moment = ZeroMoment(compute_backend=ComputeBackend.WARP)
         self.first_moment = FirstMoment(compute_backend=ComputeBackend.WARP)
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
         functional, _ = self._construct_warp()
 
         @neon.Container.factory("macroscopic")

--- a/xlb/operator/macroscopic/second_moment.py
+++ b/xlb/operator/macroscopic/second_moment.py
@@ -4,6 +4,7 @@ from functools import partial
 import jax.numpy as jnp
 from jax import jit
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 
 from xlb.compute_backend import ComputeBackend
@@ -57,12 +58,9 @@ class SecondMoment(Operator):
     def _construct_warp(self):
         # Make constants for warp
         _cc = self.velocity_set.cc
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
         _pi_dim = self.velocity_set.d * (self.velocity_set.d + 1) // 2
-        _pi_vec = wp.vec(
-            _pi_dim,
-            dtype=self.compute_dtype,
-        )
+        _pi_vec = wp.types.vector(length=_pi_dim, dtype=self.compute_dtype)
 
         # Construct functional for computing second moment
         @wp.func

--- a/xlb/operator/macroscopic/zero_moment.py
+++ b/xlb/operator/macroscopic/zero_moment.py
@@ -2,6 +2,7 @@ from functools import partial
 import jax.numpy as jnp
 from jax import jit
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 
 from xlb.compute_backend import ComputeBackend
@@ -17,7 +18,7 @@ class ZeroMoment(Operator):
         return jnp.sum(f, axis=0, keepdims=True)
 
     def _construct_warp(self):
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
 
         @wp.func
         def neumaier_sum(f: _f_vec):

--- a/xlb/operator/precision_caster/precision_caster.py
+++ b/xlb/operator/precision_caster/precision_caster.py
@@ -5,6 +5,7 @@ Base class for casting precision of the input data to the desired precision
 import jax.numpy as jnp
 from jax import jit
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from functools import partial
 
 from xlb.operator.operator import Operator
@@ -43,8 +44,8 @@ class PrecisionCaster(Operator):
 
     def _construct_warp(self):
         # Construct needed types and constants
-        from_lattice_vec = wp.vec(self.velocity_set.q, dtype=self.input_precision)
-        to_lattice_vec = wp.vec(self.velocity_set.q, dtype=self.output_precision)
+        from_lattice_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.input_precision)
+        to_lattice_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.output_precision)
         from_array_type = wp.array4d(dtype=self.input_precision)
         to_array_type = wp.array4d(dtype=self.output_precision)
         _q = wp.constant(self.velocity_set.q)

--- a/xlb/operator/stepper/ibm_stepper.py
+++ b/xlb/operator/stepper/ibm_stepper.py
@@ -1,6 +1,7 @@
 from functools import partial
 from jax import jit
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 from contextlib import nullcontext
 
@@ -121,8 +122,8 @@ class IBMStepper(IncompressibleNavierStokesStepper):
 
     def _construct_ibm_warp(self):
         # Set local constants
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
-        _missing_mask_vec = wp.vec(self.velocity_set.q, dtype=wp.uint8)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
+        _missing_mask_vec = wp.types.vector(length=self.velocity_set.q, dtype=wp.uint8)
         _opp_indices = self.velocity_set.opp_indices
         _weights = self.velocity_set.w
         _c = self.velocity_set.c

--- a/xlb/operator/stepper/nse_multires_stepper.py
+++ b/xlb/operator/stepper/nse_multires_stepper.py
@@ -68,6 +68,7 @@ Cell types are defined in `xlb.cell_type`:
 
 import nvtx
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 
 from xlb import DefaultConfig
@@ -391,8 +392,8 @@ class MultiresIncompressibleNavierStokesStepper(Stepper):
         # in a plain assignment (e.g. `_c = self.velocity_set.c`).  Capturing here
         # makes these values available as simple closure variables.
         lattice_central_index = self.velocity_set.center_index
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
-        _missing_mask_vec = wp.vec(self.velocity_set.q, dtype=wp.uint8)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
+        _missing_mask_vec = wp.types.vector(length=self.velocity_set.q, dtype=wp.uint8)
         _opp_indices = self.velocity_set.opp_indices
         _c = self.velocity_set.c
 

--- a/xlb/operator/stepper/nse_stepper.py
+++ b/xlb/operator/stepper/nse_stepper.py
@@ -10,6 +10,7 @@ from functools import partial
 
 from jax import jit
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 
 from xlb import DefaultConfig
@@ -334,8 +335,8 @@ class IncompressibleNavierStokesStepper(Stepper):
 
     def _construct_warp(self):
         # Set local constants
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
-        _missing_mask_vec = wp.vec(self.velocity_set.q, dtype=wp.uint8)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
+        _missing_mask_vec = wp.types.vector(length=self.velocity_set.q, dtype=wp.uint8)
         _opp_indices = self.velocity_set.opp_indices
         lattice_central_index = self.velocity_set.center_index
 
@@ -479,8 +480,8 @@ class IncompressibleNavierStokesStepper(Stepper):
         import neon
 
         # Set local constants
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
-        _missing_mask_vec = wp.vec(self.velocity_set.q, dtype=wp.uint8)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
+        _missing_mask_vec = wp.types.vector(length=self.velocity_set.q, dtype=wp.uint8)
         _opp_indices = self.velocity_set.opp_indices
         lattice_central_index = self.velocity_set.center_index
 

--- a/xlb/operator/stream/stream.py
+++ b/xlb/operator/stream/stream.py
@@ -9,6 +9,7 @@ from functools import partial
 import jax.numpy as jnp
 from jax import jit, vmap
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 from typing import Any
 
 from xlb.compute_backend import ComputeBackend
@@ -64,7 +65,7 @@ class Stream(Operator):
     def _construct_warp(self):
         # Set local constants TODO: This is a hack and should be fixed with warp update
         _c = self.velocity_set.c
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
 
         # Construct the funcional to get streamed indices
         @wp.func
@@ -127,7 +128,7 @@ class Stream(Operator):
     def _construct_neon(self):
         # Set local constants TODO: This is a hack and should be fixed with warp update
         _c = self.velocity_set.c
-        _f_vec = wp.vec(self.velocity_set.q, dtype=self.compute_dtype)
+        _f_vec = wp.types.vector(length=self.velocity_set.q, dtype=self.compute_dtype)
 
         # Construct the funcional to get streamed indices
         @wp.func

--- a/xlb/velocity_set/velocity_set.py
+++ b/xlb/velocity_set/velocity_set.py
@@ -9,6 +9,7 @@ indices, moments, etc.) for any DdQq stencil.  Backend-specific constants
 import math
 import numpy as np
 import warp as wp
+import warp.types  # noqa: F401  (warp-1.14 generic ctors)
 import jax.numpy as jnp
 import jax
 
@@ -87,12 +88,12 @@ class VelocitySet(object):
         Convert NumPy properties to Warp-specific properties.
         """
         dtype = self.precision_policy.compute_precision.wp_dtype
-        self.c = wp.constant(wp.mat((self.d, self.q), dtype=wp.int32)(self._c))
-        self.w = wp.constant(wp.vec(self.q, dtype=dtype)(self._w))
-        self.opp_indices = wp.constant(wp.vec(self.q, dtype=wp.int32)(self._opp_indices))
-        self.cc = wp.constant(wp.mat((self.q, self.d * (self.d + 1) // 2), dtype=dtype)(self._cc))
-        self.c_float = wp.constant(wp.mat((self.d, self.q), dtype=dtype)(self._c_float))
-        self.qi = wp.constant(wp.mat((self.q, self.d * (self.d + 1) // 2), dtype=dtype)(self._qi))
+        self.c = wp.constant(wp.types.matrix(shape=(self.d, self.q), dtype=wp.int32)(self._c))
+        self.w = wp.constant(wp.types.vector(length=self.q, dtype=dtype)(self._w))
+        self.opp_indices = wp.constant(wp.types.vector(length=self.q, dtype=wp.int32)(self._opp_indices))
+        self.cc = wp.constant(wp.types.matrix(shape=(self.q, self.d * (self.d + 1) // 2), dtype=dtype)(self._cc))
+        self.c_float = wp.constant(wp.types.matrix(shape=(self.d, self.q), dtype=dtype)(self._c_float))
+        self.qi = wp.constant(wp.types.matrix(shape=(self.q, self.d * (self.d + 1) // 2), dtype=dtype)(self._qi))
 
     def _init_neon_properties(self):
         """
@@ -128,13 +129,13 @@ class VelocitySet(object):
             self.inv_cs2 = jnp.array(self.inv_cs2, dtype=dtype)
 
     def warp_lattice_vec(self, dtype):
-        return wp.vec(len(self.c), dtype=dtype)
+        return wp.types.vector(length=len(self.c), dtype=dtype)
 
     def warp_u_vec(self, dtype):
-        return wp.vec(self.d, dtype=dtype)
+        return wp.types.vector(length=self.d, dtype=dtype)
 
     def warp_stream_mat(self, dtype):
-        return wp.mat((self.q, self.d), dtype=dtype)
+        return wp.types.matrix(shape=(self.q, self.d), dtype=dtype)
 
     def _construct_qi(self):
         # Qi = cc - cs^2*I


### PR DESCRIPTION
## Summary
- Replace deprecated generic Warp constructors with `wp.types.vector(...)` / `wp.types.matrix(...)` where types are defined outside kernels.
- Replace kernel-scope scalar vector construction with `wp.vector(...)`.
- Update `warp.utils.ScopedTimer` usage to `warp.ScopedTimer`.
- Sweep core operators, examples, and the install smoke test so XLB works with latest stable `warp-lang==1.14.0`.

## Verification
- `python -m pip index versions warp-lang` -> latest `1.14.0`
- `python -m pip index versions xlb` -> latest PyPI `0.3.1`
- `python - <<'PY' ...` import check -> Warp `1.14.0`, `has_vec=False`, `has_mat=False`, `hasattr(wp, "ScopedTimer")=True`
- `rg -n "wp\\.vec\\(|wp\\.mat\\(|warp\\.utils" xlb tests examples` -> no matches
- `python -m compileall -q examples/... tests/install/flow_past_sphere_3d_test.py`
- `pytest tests/kernels/collision/test_bgk_collision_warp.py tests/kernels/equilibrium/test_equilibrium_warp.py tests/kernels/macroscopic/test_macroscopic_warp.py tests/kernels/stream/test_stream_warp.py tests/boundary_conditions/bc_equilibrium/test_bc_equilibrium_warp.py tests/boundary_conditions/bc_fullway_bounce_back/test_bc_fullway_bounce_back_warp.py tests/boundary_conditions/mask/test_bc_indices_masker_warp.py tests/grids/test_grid_warp.py -q` -> `45 passed`
- `python tests/install/flow_past_sphere_3d_test.py` -> WARP and JAX finished; NEON skipped because `HalfwayBounceBackBC` on the sphere has no NEON implementation in XLB
